### PR TITLE
Control the nav_filter model with a parameter

### DIFF
--- a/firmware/src/board/ublox.hpp
+++ b/firmware/src/board/ublox.hpp
@@ -278,6 +278,7 @@ struct Config
 {
     float fix_rate_hz = 10;
     float aux_rate_hz = 1;
+    msg::CFG_NAV5::DynModel nav_filter_model = msg::CFG_NAV5::DynModel::Airborne_4g;
 };
 
 class Driver

--- a/firmware/src/board/ublox_msg.hpp
+++ b/firmware/src/board/ublox_msg.hpp
@@ -128,8 +128,13 @@ struct CFG_NAV5
         Sea         = 5,
         Airborne_1g = 6,
         Airborne_2g = 7,
-        Airborne_4g = 8
+        Airborne_4g = 8,
+        Wrist       = 9 // only exsits in proto >= 18
     } dynModel;
+
+#define GNSS_DYN_MODEL_MIN     0
+#define GNSS_DYN_MODEL_MAX     9
+#define GNSS_DYN_MODEL_DEFAULT 8
 
     enum class FixMode : U1
     {

--- a/firmware/src/gnss.cpp
+++ b/firmware/src/gnss.cpp
@@ -51,6 +51,10 @@ os::config::Param<unsigned> param_gnss_aux_prio("uavcan.prio-aux",
                                                 uavcan::TransferPriority::NumericallyMin,
                                                 uavcan::TransferPriority::NumericallyMax);
 
+os::config::Param<unsigned> param_gnss_nav_filter_model("gnss.filter_mode",
+                                                        GNSS_DYN_MODEL_DEFAULT,
+                                                        GNSS_DYN_MODEL_MIN,
+                                                        GNSS_DYN_MODEL_MAX);
 os::config::Param<unsigned> param_gnss_warn_min_fix_dimensions("gnss.warn_dimens", 0, 0, 3);
 os::config::Param<unsigned> param_gnss_warn_min_sats_used("gnss.warn_sats", 0, 0, 20);
 
@@ -232,6 +236,7 @@ class GnssThread : public chibios_rt::BaseStaticThread<3000>
         auto cfg = ublox::Config();
         cfg.fix_rate_hz = 1e6F / param_gnss_fix_period_usec.get();
         cfg.aux_rate_hz = 1e6F / param_gnss_aux_period_usec.get();
+        cfg.nav_filter_model = static_cast<ublox::msg::CFG_NAV5::DynModel>(param_gnss_nav_filter_model.get());
 
         while (shouldKeepGoing() && !driver_.configure(cfg, watchdog_))
         {


### PR DESCRIPTION
Also updates default value of the nav_filter from Airborne_2g to Airborne_4g. (APM testing shows that Airborne_4g has less filtering on the data, and the minimum amount of filtering is desired).

Also updates the list of DynModels to acknowledge that 9 is the dynamic model for wrists, its only used in newer GPS firmware, but the GPS chip can be upgraded to that firmware.
